### PR TITLE
bug in server() method using https.

### DIFF
--- a/phploader/combo_functions.inc.php
+++ b/phploader/combo_functions.inc.php
@@ -11,7 +11,7 @@
 //(modified version of full_url), license: MIT
 function server($includeRequestUri=false)
 {
-    $s = getenv('HTTPS') ? '' : (getenv('HTTPS') ==     'on') ? 's' : '';
+    $s = getenv('HTTPS') ? ((getenv('HTTPS') == 'on') ? 's' : '') : '');
     $protocol = substr(
         strtolower(getenv('SERVER_PROTOCOL')), 0, 
         strpos(strtolower(getenv('SERVER_PROTOCOL')), '/')


### PR DESCRIPTION
bug in server() method using https. The url result had always been without 's', so that browsers start to warn about insecure items.
